### PR TITLE
Fix Pandas version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ outputs:
       run:
         - python
         - packaging
-        - pandas ==1.3
+        - pandas ==1.3.2
         - numpy >=1.16.5
     test:
       imports:


### PR DESCRIPTION
Update Pandas version to 1.3.2, cause of incompatibility with current version of modin-pandas. Version of pandas must match with modin-pandas. With current build command we have warning like this:
`UserWarning: The pandas version installed 1.3.0 does not match the supported pandas version in Modin 1.3.2. This may cause undesired side effects!`